### PR TITLE
-rt 参数支持保存RefreshToken的文件路径

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,15 @@
 > 选择对应的版本进行下载,进入到解压目录执行
 ```bash
 ./webdav -rt="your refreshToken"
+# 或者
+echo "your refreshToken" > /path/to/save/refreshToken
+./webdav -rt /path/to/save/refreshToken
 ```
 
 # 参数说明
 ```bash
 -rt
-    阿里云盘的refreshToken，获取方式见下文
+    阿里云盘的refreshToken，获取方式见下文。或者包含refreshToken的文件路径。
 -port
     非必填，服务器端口号，默认为8085
 -user


### PR DESCRIPTION
有时候路由器需要 reboot 但是 RefreshToken 又需要开电脑重新获取，
所以 `-rt` 参数加这个功能：
如果 指定的是 RefreshToken 逻辑不变，
如果 指定的是 文件路径，并且里面包含了 RefreshToken，那么每次刷新token的时候会记录到该文件，路由器reboot后，能直接利用这个文件自动启动。